### PR TITLE
Add Serde Integration

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,15 +19,15 @@ jobs:
       - uses: actions/checkout@v1
       - run: rustup update
       - run: rustup component add clippy
-      - run: cargo clippy --all --all-targets
+      - run: cargo clippy --all --all-targets --all-features
 
   test:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
       - run: rustup update
-      - run: cargo build
-      - run: cargo test --verbose --all --all-targets
+      - run: cargo build --all-features
+      - run: cargo test --verbose --all --all-targets --all-features
         env:
           RUST_BACKTRACE: 1
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 /target
 Cargo.lock
+
+.idea

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxilangtag"
-version = "0.2.0"
+version = "0.1.3"
 authors = [
     "Tpt <thomas@pellissier-tanon.fr>"
 ]
@@ -15,7 +15,7 @@ edition = "2018"
 
 [features]
 default = []
-serde = ["serde/derive"]
+serialize = ["serde/derive"]
 
 [dependencies.serde]
 version = "1.0"
@@ -31,4 +31,4 @@ harness = false
 
 # enable serde in docs.rs
 [package.metadata.docs.rs]
-features = ["serde"]
+all-features = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ optional = true
 
 [dev-dependencies]
 criterion = "0.3"
+serde_json = "1.0"
 
 [[bench]]
 name = "lib"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxilangtag"
-version = "0.1.2"
+version = "0.2.0"
 authors = [
     "Tpt <thomas@pellissier-tanon.fr>"
 ]
@@ -13,9 +13,21 @@ Simple and fast implementation of language tag normalization and validation
 """
 edition = "2018"
 
+[features]
+default = []
+serde = ["serde/derive"]
+
+[dependencies.serde]
+version = "1.0"
+optional = true
+
 [dev-dependencies]
 criterion = "0.3"
 
 [[bench]]
 name = "lib"
 harness = false
+
+# enable serde in docs.rs
+[package.metadata.docs.rs]
+features = ["serde"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ edition = "2018"
 
 [features]
 default = []
-serialize = ["serde/derive"]
+serialize = ["serde"]
 
 [dependencies.serde]
 version = "1.0"

--- a/README.md
+++ b/README.md
@@ -32,6 +32,9 @@ assert_eq!(language_tag.extension(), None);
 assert_eq!(language_tag.private_use_subtags().collect::<Vec<_>>(), vec!["test"]);
 ```
 
+## Features
+- `serde`: Enables `serde` integration. NOTE: To use the serde integration properly, use 
+ `[serde(into = "String")]` and `#[serde(try_from = "String")]`. If you want to be infalliable, use `SerdeLanguageTag`.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -33,8 +33,7 @@ assert_eq!(language_tag.private_use_subtags().collect::<Vec<_>>(), vec!["test"])
 ```
 
 ## Features
-- `serde`: Enables `serde` integration. NOTE: To use the serde integration properly, use 
- `[serde(into = "String")]` and `#[serde(try_from = "String")]`. If you want to be infalliable, use `SerdeLanguageTag`.
+- `serialize`: Enables `serde` integration. 
 
 ## License
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -493,6 +493,18 @@ impl TryFrom<String> for LanguageTag<String> {
 /// Language Tag Type that is infallable when used with `serde`'s [decorators](https://serde.rs/container-attrs.html#from). This is accomplished
 /// by having a default trait that auto-resolves to `en-US`. You must have crate feature `serde` enabled to use this.
 ///
+/// Example:
+/// ```
+/// use oxilangtag::SerdeLanguageTag;
+/// use serde::{Serialize, Deserialize};
+///
+/// pub struct ContainerStruct {
+///     #[serde(into = "String", from = "String")]
+///     language: SerdeLanguageTag
+/// }
+/// ```
+///
+/// use oxilangtag::LanguageTag;
 /// See [`LanguageTag`] for details.
 #[derive(Clone, Debug)]
 pub struct SerdeLanguageTag {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -541,6 +541,27 @@ impl From<LanguageTag<String>> for SerdeLanguageTag {
     }
 }
 
+#[cfg(feature = "serde")]
+impl Into<String> for SerdeLanguageTag {
+    fn into(self) -> String {
+        self.lang_tag.into()
+    }
+}
+
+#[cfg(feature = "serde")]
+impl From<String> for SerdeLanguageTag {
+    fn from(s: String) -> Self {
+        match LanguageTag::parse(s) {
+            Ok(lang_tag) => {
+                lang_tag.into()
+            }
+            Err(_) => {
+                SerdeLanguageTag::default()
+            }
+        }
+    }
+}
+
 /// An error raised during [`LanguageTag`](struct.LanguageTag.html) validation.
 #[derive(Debug)]
 pub struct LanguageTagParseError {

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -1,8 +1,6 @@
 use oxilangtag::LanguageTag;
 use std::collections::hash_map::DefaultHasher;
 use std::hash::{Hash, Hasher};
-#[cfg(feature = "serde")]
-use oxilangtag::SerdeLanguageTag;
 
 // Tests from RFC 5646 2.1.1
 #[test]
@@ -699,7 +697,7 @@ fn test_str() {
     assert!(tag.starts_with("en-"));
 }
 
-#[cfg(feature = "serde")]
+#[cfg(feature = "serialize")]
 #[test]
 fn test_langtag_serialize_deserialize_valid() {
     let tag = LanguageTag::parse("en-US".to_string()).unwrap();
@@ -708,26 +706,9 @@ fn test_langtag_serialize_deserialize_valid() {
     assert_eq!(deserialize_json, tag);
 }
 
-#[cfg(feature = "serde")]
+#[cfg(feature = "serialize")]
 #[test]
 fn test_langtag_serialize_deserialize_invalid() {
     let deserialize_json: Result<LanguageTag<String>, _> = serde_json::from_str("estrogen pogger!"); // this will fail
     assert!(deserialize_json.is_err());
-}
-
-#[cfg(feature = "serde")]
-#[test]
-fn test_serdelangtag_serialize_deserialize_valid() {
-    let tag: SerdeLanguageTag = LanguageTag::parse("en-US".to_string()).unwrap().into();
-    let serialize_json = serde_json::to_string(&tag).unwrap();
-    println!("{}", serialize_json);
-    let deserialize_json: SerdeLanguageTag = serde_json::from_str(&serialize_json).unwrap();
-    assert_eq!(deserialize_json, tag);
-}
-
-#[cfg(feature = "serde")]
-#[test]
-fn test_serdelangtag_serialize_deserialize_invalid() {
-    let deserialize_json: SerdeLanguageTag = serde_json::from_str(r#""wdawadwadawd""#).unwrap(); // this will fail
-    assert_eq!(deserialize_json, SerdeLanguageTag::default());
 }

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -1,6 +1,8 @@
 use oxilangtag::LanguageTag;
 use std::collections::hash_map::DefaultHasher;
 use std::hash::{Hash, Hasher};
+#[cfg(feature = "serde")]
+use oxilangtag::SerdeLanguageTag;
 
 // Tests from RFC 5646 2.1.1
 #[test]
@@ -695,4 +697,37 @@ fn hash(value: impl Hash) -> u64 {
 fn test_str() {
     let tag = LanguageTag::parse("en-fr").unwrap();
     assert!(tag.starts_with("en-"));
+}
+
+#[cfg(feature = "serde")]
+#[test]
+fn test_langtag_serialize_deserialize_valid() {
+    let tag = LanguageTag::parse("en-US".to_string()).unwrap();
+    let serialize_json = serde_json::to_string(&tag).unwrap();
+    let deserialize_json: LanguageTag<String> = serde_json::from_str(&serialize_json).unwrap();
+    assert_eq!(deserialize_json, tag);
+}
+
+#[cfg(feature = "serde")]
+#[test]
+fn test_langtag_serialize_deserialize_invalid() {
+    let deserialize_json: Result<LanguageTag<String>, _> = serde_json::from_str("estrogen pogger!"); // this will fail
+    assert!(deserialize_json.is_err());
+}
+
+#[cfg(feature = "serde")]
+#[test]
+fn test_serdelangtag_serialize_deserialize_valid() {
+    let tag: SerdeLanguageTag = LanguageTag::parse("en-US".to_string()).unwrap().into();
+    let serialize_json = serde_json::to_string(&tag).unwrap();
+    println!("{}", serialize_json);
+    let deserialize_json: SerdeLanguageTag = serde_json::from_str(&serialize_json).unwrap();
+    assert_eq!(deserialize_json, tag);
+}
+
+#[cfg(feature = "serde")]
+#[test]
+fn test_serdelangtag_serialize_deserialize_invalid() {
+    let deserialize_json: SerdeLanguageTag = serde_json::from_str(r#""wdawadwadawd""#).unwrap(); // this will fail
+    assert_eq!(deserialize_json, SerdeLanguageTag::default());
 }


### PR DESCRIPTION
Adds serde integration, allowing users to use serde with oxilangtag  by using feature `serde`. Bumped to 0.2 in case anyone depended on oxilangtag not supporting serde. 